### PR TITLE
update: mix-manifest.json is excluded from Git's control

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -14,3 +14,4 @@ yarn-error.log
 /.idea
 /.vscode
 /public/js/*
+/public/mix-manifest.json

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,3 +1,0 @@
-{
-    "/js/index.js": "/js/index.js?id=13d296ce1671f32b89bc177ef7a6a7d2"
-}


### PR DESCRIPTION
・mix-manifest.jsonをGitの管理から除外しました。